### PR TITLE
Fix a dependency for activeadmin

### DIFF
--- a/activeadmin-refinerycms-authentication.gemspec
+++ b/activeadmin-refinerycms-authentication.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name          = "activeadmin-refinerycms-authentication"
-  s.version       = "0.0.3"
+  s.version       = "0.0.3.1"
   s.authors       = ["eugen neagoe"]
   s.description   = "A Refinery CMS and activeadmin connector"
   s.summary       = "This will tell Refinery CMS to use ActiveAdmin for authentication."
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^spec/})
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'activeadmin', '~> 1.0.0pre'
+  s.add_runtime_dependency 'activeadmin', '~> 1.0.0pre1'
 
   s.add_runtime_dependency 'refinerycms-core', '~> 3.0.0'
   s.add_runtime_dependency 'zilch-authorisation', '>= 0.0.1'


### PR DESCRIPTION
the gem  version 1.0.0pre can't be found anymore